### PR TITLE
Detect launch failure

### DIFF
--- a/mcu/src/org/smbarbour/mcu/LauncherThread.java
+++ b/mcu/src/org/smbarbour/mcu/LauncherThread.java
@@ -30,7 +30,7 @@ public class LauncherThread implements Runnable {
 	
 	@Override
 	public void run() {
-		ProcessBuilder pb = new ProcessBuilder("java","-Xms"+minMem, "-Xmx"+maxMem, "-jar", launcher.getPath());
+		ProcessBuilder pb = new ProcessBuilder("java","-Xms"+minMem, "-Xmx"+maxMem, "-jar", launcher.getPath(), "--noupdate");
 		pb.redirectErrorStream(true);
 		BufferedWriter buffWrite = null;
 		try {


### PR DESCRIPTION
By watching the process output, we detect the two common error messages from the JVM and display a dialog to players when they ask for too much ram.

Also suppresses the update prompt so people don't ruin their jarfiles so soon after updating.
