### PR TITLE
First pass caching of downloads

### DIFF
--- a/MCU-API/src/org/smbarbour/mcu/util/DownloadCache.java
+++ b/MCU-API/src/org/smbarbour/mcu/util/DownloadCache.java
@@ -1,0 +1,70 @@
+package org.smbarbour.mcu.util;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.FileUtils;
+
+public class DownloadCache {
+	private static DownloadCache instance;
+	private File dir;
+	
+	private DownloadCache(File dir) {
+		this.dir = dir;
+	}
+	
+	public static void init(File dir) {
+		if( instance != null ) {
+			throw new IllegalArgumentException("Attempt to reinitialize download cache.");
+		}
+		instance = new DownloadCache(dir);
+	}
+	
+	public static File getDir() {
+		instance.dir.mkdirs();
+		return instance.dir;
+	}
+	
+	public static boolean cacheFile(File file, String expectedMD5) {
+		byte[] hash;
+		try {
+			InputStream is = new FileInputStream(file);
+			hash = DigestUtils.md5(is);
+			is.close();		
+		} catch (FileNotFoundException e) {
+			e.printStackTrace();
+			return false;
+		} catch (IOException e) {
+			e.printStackTrace();
+			return false;
+		}
+		String chksum = new String(Hex.encodeHex(hash));
+		if( !chksum.equals(expectedMD5) ) {
+			// checksums do not match, abort :)
+			return false;
+		}
+		
+		File destFile = getFile(chksum);
+		if( !destFile.exists() ) {
+			try {
+				FileUtils.copyFile(file, destFile);
+			} catch (IOException e) {
+				e.printStackTrace();
+				return false;
+			}
+		}
+		
+		return true;
+	}
+	
+	public static File getFile(String chksum) {
+		final File file = new File( getDir().getAbsolutePath() + MCUpdater.sep + chksum + ".bin");
+		return file;
+	}
+}

--- a/MCU-API/src/org/smbarbour/mcu/util/MCUpdater.java
+++ b/MCU-API/src/org/smbarbour/mcu/util/MCUpdater.java
@@ -63,6 +63,8 @@ public class MCUpdater {
 		} catch (MalformedURLException e) {
 			e.printStackTrace();
 		}
+		// configure the download cache
+		DownloadCache.init(new File(MCFolder + sep + "mcu" + sep + "cache"));
 	}
 	
 	public MCUApp getParent() {
@@ -670,7 +672,6 @@ public class MCUpdater {
 					modPath.mkdirs();
 					//System.out.println(modPath.getPath());
 					try {
-						
 						ModDownload normalMod = new ModDownload(modURL, modPath, entry.getMD5());
 						System.out.println(normalMod.getRemoteFilename() + " -> " + normalMod.getDestFile().getPath());
 					} catch (Exception e) {


### PR DESCRIPTION
If an MD5 is specified for a file:
1. The cache is checked for an existing file, which is used instead of re-downloading.
2. If the cache misses, the file is then downloaded as normal. It is then saved as mcu/cache/<md5>.bin provided the downloaded file matches the checksum in the serverpack xml.

Currently, there is no indication of cache behavior given to the console - only stdout along with the rest of the download spam.
